### PR TITLE
Corrige exibição do nome do autor nas postagens

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -91,6 +91,8 @@ if ( ! function_exists( 'coletivo_posted_on' ) ) {
      */
     function coletivo_posted_on()
     {
+        the_post();
+
         $time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
         if (get_the_time('U') !== get_the_modified_time('U')) {
             $time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated hide" datetime="%3$s">%4$s</time>';
@@ -115,6 +117,7 @@ if ( ! function_exists( 'coletivo_posted_on' ) ) {
 
         echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.
 
+        rewind_posts();
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -1463,10 +1463,6 @@ body.blog.blog-list-style .list-article-thumb img {
 	font-weight: 600;
 }
 
-.entry-meta span.byline {
-	display: none;
-}
-
 .entry-footer {
 	margin-bottom: 30px;
 }


### PR DESCRIPTION
## Porque foi necessário?

O nome do autor não estava sendo exibido e o link para a página do autor estava incorreto no cabeçalho das postagens.

Ref.: #27 

## O que foi feito?

As funções utilizadas para recupera o `ID` e nome do `author` só funcionam dentro do loop e estavam sendo utilizadas fora do loop. Para resolver adicionei `the_post()` antes de chamar as funções para iterar o post e fazer as funções funcionarem e `rewind_posts()` no final para retroceder a iteração e não comprometer nenhum loop.

Removi o `display:none` que foi adicionado como medida paliativa na tag que exibe o nome do autor para fazer com que voltasse a aparecer.

## Como testar?

1 - Clona essa branh;
2 - Acessa a página single de qualquer post;
3 - Verifica se o nome do autor está aparecendo no cabeçalho da página e se o link no nome leva para a página do autor.

| ![Captura de Tela 2019-06-07 às 22 47 29](https://user-images.githubusercontent.com/957257/59140588-46e3ef00-8976-11e9-8ff0-3d9d8a4bb56f.png) |
:--:
| *Exemplo de como deve ficar* |
