### PR TITLE
Correção no link do facebook

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -2495,7 +2495,7 @@ function coletivo_customize_register( $wp_customize ) {
 		array(
 			'label'     	=> esc_html__('Facebook', 'coletivo'),
 			'section' 		=> 'coletivo_contact_content',
-			'description'   => esc_html__('Enter the adress without http://', 'coletivo')
+			'description'   => esc_html__('Enter the name of the page url after the "/" (example of url https://www.facebook.com/facebook, just put facebook)', 'coletivo')
 			)
 	);
 	$wp_customize->add_setting( 'coletivo_contact_instagram',

--- a/section-parts/section-contact.php
+++ b/section-parts/section-contact.php
@@ -100,7 +100,7 @@ if ( $coletivo_contact_cf7 || $coletivo_contact_text || $coletivo_contact_addres
                                 <div class="address-contact">
                                     <span class="fa-stack"><i class="fa fa-circle fa-stack-2x"></i><i class="fa fa-facebook fa-stack-1x fa-inverse"></i></span>
 
-                                    <div class="address-content"><a href="http://<?php echo wp_kses_post($coletivo_contact_fb); ?>" target="_blank"><?php echo wp_kses_post($coletivo_contact_fb); ?></a></div>
+                                    <div class="address-content"><a href=" https://www.facebook.com/<?php echo wp_kses_post($coletivo_contact_fb); ?>" target="_blank"><?php echo wp_kses_post($coletivo_contact_fb); ?></a></div>
                                 </div>
                             <?php endif; ?>
 


### PR DESCRIPTION
Fica muito ruim apresentando a URL do Facebook na pagina, foi feita a correção para pessoa somente colocar o que vem depois do  https://www.facebook.com/nomedapagina